### PR TITLE
Retain namespace context

### DIFF
--- a/lib/superform.rb
+++ b/lib/superform.rb
@@ -105,7 +105,7 @@ module Superform
     # end
     # ```
     def namespace(key, &block)
-      create_child(key, self.class, object: object_for(key: key), &block)
+      create_child(key, self.class, field_class: @field_class, object: object_for(key: key), &block)
     end
 
     # Maps the `Object#proprety` and `Object#property=` to a field in a web form that can be
@@ -162,7 +162,7 @@ module Superform
     # Assigns a hash to the current namespace and children namespace.
     def assign(hash)
       each do |child|
-        child.assign hash[child.key]
+        child.assign(hash.fetch(child.key, nil))
       end
       self
     end
@@ -189,7 +189,13 @@ module Superform
     # Checks if the child exists. If it does then it returns that. If it doesn't, it will
     # build the child.
     def create_child(key, child_class, **kwargs, &block)
-      @children.fetch(key) { @children[key] = child_class.new(key, parent: self, **kwargs, &block) }
+      if (child = @children.fetch(key, nil))
+        # ensure that found children are also yielded
+        child.tap { yield child if block_given? }
+      else
+        # new children added to hash and block passed to constructor
+        @children[key] = child_class.new(key, parent: self, **kwargs, &block)
+      end
     end
   end
 

--- a/spec/superform_spec.rb
+++ b/spec/superform_spec.rb
@@ -110,19 +110,6 @@ RSpec.describe Superform do
       expect(form_with_email_field.field(:email).input.dom.name).to eql("user[email]")
     end
 
-    # This test passed before changes to superform.rb, it replicates the bug in the original code (raises NoMethodError)
-    # it "raises NoMethodError when calling input on a field within a namespace" do
-    #   form_with_ns = Superform :user, object: user, field_class: Superform::Rails::Form::Field do |f|
-    #     f.namespace(:settings) do |settings|
-    #       settings.field(:locale)
-    #     end
-    #   end
-
-    #   expect {
-    #     form_with_ns.namespace(:settings).field(:locale).input
-    #   }.to raise_error(NoMethodError, /undefined method `input'/)
-    # end
-
     it "returns an InputComponent when calling input on a field within a namespace" do
       form_with_ns = Superform :user, object: user, field_class: Superform::Rails::Form::Field do |f|
         f.namespace(:settings) do |settings|


### PR DESCRIPTION
Based on #27

---

These changes ensure that the namespace is retained. It fixes the following bug:

Basic example:

```rb
class ProposalsForm < Superform::Rails::Form
  def view_template(&)
    namespace :settings do |settings|
      render settings.field(:locale).input
    end
  end 
end
```

I expected this to produce:

```html
<input id="proposal_settings_locale" name="proposal[settings][locale]" value="current value is properly set" type="text">
```

However, I get:

```txt
NoMethodError in ProposalsController#edit
undefined method `input` for an instance of Superform::Field
```

See reproduction in b82992ff7b471a182c32e0db8b5ad717255c63a2