### PR TITLE
Client-side HTML 5 validations

### DIFF
--- a/lib/superform/rails/components/checkbox.rb
+++ b/lib/superform/rails/components/checkbox.rb
@@ -2,6 +2,8 @@ module Superform
   module Rails
     module Components
       class Checkbox < Field
+        prepend Concerns::Requirable
+
         def view_template(&)
           # Rails has a hidden and checkbox input to deal with sending back a value
           # to the server regardless of if the input is checked or not.

--- a/lib/superform/rails/components/concerns/requirable.rb
+++ b/lib/superform/rails/components/concerns/requirable.rb
@@ -1,0 +1,24 @@
+module Superform
+  module Rails
+    module Components
+      module Concerns
+        module Requirable
+          def field_attributes
+            super.merge(validation_attributes)
+          end
+
+          def validation_attributes
+            return {} unless presence_validated?
+            { required: true }
+          end
+
+          def presence_validated?
+            object = field.parent&.object
+            return false unless object&.class&.respond_to?(:validators_on)
+            object.class.validators_on(field.key).any? { |v| v.kind == :presence }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/superform/rails/components/input.rb
+++ b/lib/superform/rails/components/input.rb
@@ -2,6 +2,8 @@ module Superform
   module Rails
     module Components
       class Input < Field
+        prepend Concerns::Requirable
+
         def view_template(&)
           input(**attributes)
         end

--- a/lib/superform/rails/components/select.rb
+++ b/lib/superform/rails/components/select.rb
@@ -2,6 +2,8 @@ module Superform
   module Rails
     module Components
       class Select < Field
+        prepend Concerns::Requirable
+
         def initialize(*, collection: [], **, &)
           super(*, **, &)
           @collection = collection

--- a/lib/superform/rails/components/textarea.rb
+++ b/lib/superform/rails/components/textarea.rb
@@ -2,6 +2,8 @@ module Superform
   module Rails
     module Components
       class Textarea < Field
+        prepend Concerns::Requirable
+
         def view_template(&content)
           content ||= Proc.new { dom.value }
           textarea(**attributes, &content)

--- a/spec/superform/rails/field_convenience_methods_spec.rb
+++ b/spec/superform/rails/field_convenience_methods_spec.rb
@@ -60,4 +60,78 @@ RSpec.describe Superform::Rails::Form::Field do
       expect(component.type).to eq("radio")
     end
   end
+
+  describe "HTML5 client-side validations" do
+    context "input" do
+      it "adds required when presence validation exists" do
+        component = field.input
+        expect(component.field_attributes[:required]).to eq(true)
+      end
+
+      it "does not add required when no presence validation" do
+        component = form.field(:last_name).input
+        expect(component.field_attributes.key?(:required)).to eq(false)
+      end
+
+      it "allows required: false to override" do
+        component = field.input(required: false)
+        attrs = component.send(:attributes)
+        expect(attrs[:required]).to eq(false)
+      end
+    end
+
+    context "checkbox" do
+      it "adds required when presence validation exists" do
+        component = field.checkbox
+        expect(component.field_attributes[:required]).to eq(true)
+      end
+
+      it "does not add required when no presence validation" do
+        component = form.field(:last_name).checkbox
+        expect(component.field_attributes.key?(:required)).to eq(false)
+      end
+
+      it "allows required: false to override" do
+        component = field.checkbox(required: false)
+        attrs = component.send(:attributes)
+        expect(attrs[:required]).to eq(false)
+      end
+    end
+
+    context "textarea" do
+      it "adds required when presence validation exists" do
+        component = field.textarea
+        expect(component.field_attributes[:required]).to eq(true)
+      end
+
+      it "does not add required when no presence validation" do
+        component = form.field(:last_name).textarea
+        expect(component.field_attributes.key?(:required)).to eq(false)
+      end
+
+      it "allows required: false to override" do
+        component = field.textarea(required: false)
+        attrs = component.send(:attributes)
+        expect(attrs[:required]).to eq(false)
+      end
+    end
+
+    context "select" do
+      it "adds required when presence validation exists" do
+        component = field.select("a", "b")
+        expect(component.field_attributes[:required]).to eq(true)
+      end
+
+      it "does not add required when no presence validation" do
+        component = form.field(:last_name).select("a", "b")
+        expect(component.field_attributes.key?(:required)).to eq(false)
+      end
+
+      it "allows required: false to override" do
+        component = field.select("a", "b", required: false)
+        attrs = component.send(:attributes)
+        expect(attrs[:required]).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Spotted an issue for this (https://github.com/beautifulruby/superform/issues/46) and figured I'd take a crack at it!

This PR adds a `Requirable` concern that checks a form's underlying class for a presence validator on the relevant field (`presence_validated?`) and merges `required: true` into the field's attributes if such a validation is detected. If `required: false` is passed in, that value will be respected. I added the concern to `Checkbox`, `Input`, `Select`, and `Textarea`, since those are the field types that can take advantage of `required`. I also added some specs covering the `Requirable` behavior for all four.

Note: I wasn't sure if a concern was the way to go here. Putting this logic directly in `Field` felt possibly weird, so I just went with a concern to keep things modular/contained.